### PR TITLE
Catch errors from api.chain.com

### DIFF
--- a/http-utility.js
+++ b/http-utility.js
@@ -36,11 +36,14 @@ HttpUtility.prototype.makeRequest = function(method, path, body, options, cb) {
   if(options != null) {
     r['qs'] = options;
   }
-  request(r, function(err, msg, resp) {
+  request(r, function(err, resp, body) {
+    if (Math.floor(resp.statusCode / 100) != 2) {
+      err = body;
+    }
     if(usingJson) {
-      cb(err, resp);
+      cb(err, body);
     } else {
-      cb(err, JSON.parse(resp));
+      cb(err, JSON.parse(body));
     }
   });
 };


### PR DESCRIPTION
Prior to this patch, the only errors
that were passed to the callback functions
were low-level request errors. Chain API
errors were not being passed as errors to the callback funciton.

When the Chain API returns a non-200 response, the body of the
response contains an error object explaining what went wrong.