### PR TITLE
Expose the PEM certificate in http-utility, so that it can be used to ma...

### DIFF
--- a/http-utility.js
+++ b/http-utility.js
@@ -18,13 +18,15 @@ function HttpUtility(c) {
     c.url = URL;
   };
   this.url = c.url;
+
+  this.PEM = PEM;
 }
 
 HttpUtility.prototype.makeRequest = function(method, path, body, options, cb) {
   var usingJson = false;
   var r = {
     strictSSL: true,
-    cert: PEM,
+    cert: this.PEM,
     auth: this.auth,
     method: method,
     uri: this.url + path


### PR DESCRIPTION
...ke queries external to the packaged requests.

I cam across this because I'm using this library for most of my calls, but needed to replicate the call to request in order to support chaining (which uses the response headers, not just the content).